### PR TITLE
Fix for Control + S saving of editor changes, keydown used to account for all OS cases

### DIFF
--- a/media/jetpack/js/Package.js
+++ b/media/jetpack/js/Package.js
@@ -1014,9 +1014,8 @@ Package.Edit = new Class({
 
 	bind_keyboard: function() {
 		this.keyboard = new Keyboard({
-			defaultEventType: 'keyup',
 			events: {
-			'ctrl+s': this.boundSaveAction
+				'ctrl+s': this.boundSaveAction
 			}
 		});
 		this.keyboard.activate();


### PR DESCRIPTION
This should fix control S saving of unsaved editor data
