### PR TITLE
Bug 663472: replace invalid rel attribute with data-jetpackid

### DIFF
--- a/apps/jetpack/templates/_package_browser_addon.html
+++ b/apps/jetpack/templates/_package_browser_addon.html
@@ -16,7 +16,7 @@
 <ul class="UI_Actions">
 	<li class="UI_Try_in_Browser XPI_test">
     <a title="Test Add-on" href="{{ item.latest.get_test_xpi_url }}" 
-        rel="{{ item.jid }}" data-hashtag="{% hashtag %}">Test</a>
+        data-jetpackid="{{ item.jid }}" data-hashtag="{% hashtag %}">Test</a>
 	</li>
 	{% include "_package_edit_view_source_bar.html" %}
 </ul>

--- a/media/base/js/FlightDeck.js
+++ b/media/base/js/FlightDeck.js
@@ -113,7 +113,7 @@ var FlightDeck = new Class({
         var installed = (this.isAddonInstalled()) ? this.isXpiInstalled() : false;
         if (installed) {
             $$('.{try_in_browser_class} a'.substitute(this.options)).each(function(test_button){
-                if (installed && installed.installedID == test_button.get('rel')) {
+                if (installed && installed.installedID == test_button.get('data-jetpackid')) {
                     test_button.getParent('li').addClass('pressed');
                 } else {
                     test_button.getParent('li').removeClass('pressed');

--- a/media/jetpack/js/FlightDeck.Browser.js
+++ b/media/jetpack/js/FlightDeck.Browser.js
@@ -23,7 +23,7 @@
             }.bind(this);
             if (fd.alertIfNoAddOn()) {
                 if (el.getParent('li').hasClass('pressed')) {
-                    fd.uninstallXPI(el.get('rel'));
+                    fd.uninstallXPI(el.get('data-jetpackid'));
                 } else {
                     testThisXpi();
                 }

--- a/media/jetpack/js/Package.js
+++ b/media/jetpack/js/Package.js
@@ -187,7 +187,7 @@ var Package = new Class({
 				el = $(this.options.test_el);
 			}
 			if (el.getParent('li').hasClass('pressed')) {
-				fd.uninstallXPI(el.get('rel'));
+				fd.uninstallXPI(el.get('data-jetpackid'));
 			} else {
 				this.installAddon();
 			}


### PR DESCRIPTION
This change causes the homepage/search results page to validate while maintaining the add-on testing functionality.
