### PR TITLE
Search activity dynamic curve

### DIFF
--- a/apps/search/helpers.py
+++ b/apps/search/helpers.py
@@ -74,7 +74,11 @@ def _get_average_activity():
     # TODO: ES has statistical facet that can provide average, but I couldn't
     # get it working.
     values = Package.search().values('activity')
-    average = sum(v[1] for v in values) / len(values)
+    num = len(values)
+    if num > 0:
+        average = sum(v[1] for v in values) / len(values)
+    else:
+        average = 0.33
 
     cache.set(ACTIVITY_CACHE_KEY, average, 60*60*24)
     return average

--- a/apps/search/helpers.py
+++ b/apps/search/helpers.py
@@ -1,3 +1,5 @@
+from django.core.cache import cache
+
 from elasticutils import S, F
 from jetpack.models import Package
 
@@ -41,3 +43,38 @@ def package_query(q):
                 full_name__fuzzy={'value': q, 'boost': 2, 'prefix_length': 4},
                 full_name__startswith={'value': q, 'boost': 1.5},
                 description__text={'query': q, 'boost': 0.8})
+
+
+ACTIVITY_MAP = {
+    '0': 0,   #dead
+    '1': 0.1, #stale
+    '2': 0.2, #low
+    '3': 0.4, #moderate
+    '4': 0.6, #high
+    '5': 0.8, #fresh
+}
+
+def get_activity_scale():
+    avg = _get_average_activity()
+    # average should be considered 1/3 (middle of Low)
+    # so total percentage is triple the average
+    total = avg * 3
+
+    act_map = dict((k, v*total) for k, v in ACTIVITY_MAP.items())
+
+    return act_map
+
+
+ACTIVITY_CACHE_KEY = 'search:activity:average'
+
+def _get_average_activity():
+    average = cache.get(ACTIVITY_CACHE_KEY)
+    if average:
+        return average
+    # TODO: ES has statistical facet that can provide average, but I couldn't
+    # get it working.
+    values = Package.search().values('activity')
+    average = sum(v[1] for v in values) / len(values)
+
+    cache.set(ACTIVITY_CACHE_KEY, average, 60*60*24)
+    return average

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -5,19 +5,11 @@ from django.shortcuts import render_to_response, redirect
 from django.template import RequestContext
 
 from jetpack.models import Package
-from .helpers import package_search
+from .helpers import package_search, get_activity_scale
 from .forms import SearchForm
 
 log = commonware.log.getLogger('f.search')
 
-ACTIVITY_MAP = {
-    '0': 0,   #dead
-    '1': 0.1, #stale
-    '2': 0.2, #low
-    '3': 0.4, #moderate
-    '4': 0.6, #high
-    '5': 0.8, #fresh
-}
 
 def search(request):
     form = SearchForm(request.GET)
@@ -28,6 +20,7 @@ def search(request):
     types = {'a': 'addon', 'l': 'library'}
     page = query.get('page') or 1
     limit = 20
+    activity_map = get_activity_scale()
 
 
     filters = {}
@@ -50,7 +43,7 @@ def search(request):
         query['used'] = 0
 
     if query.get('activity'):
-        filters['activity__gte'] = ACTIVITY_MAP.get(str(query['activity']), 0)
+        filters['activity__gte'] = activity_map.get(str(query['activity']), 0)
 
     results = {}
     facets = {}


### PR DESCRIPTION
This makes the "activity map" which decides what percentages are considered "Low", "Medium", etc to be dynamic based on the current average activity of all Packages on FlightDeck.

The average is stored in memcached for a day.

fixes Bug 689385 - Make Search Activity ratings based on current average

@zalun: r?
