### PR TITLE
Fix package activity cron

### DIFF
--- a/apps/jetpack/cron.py
+++ b/apps/jetpack/cron.py
@@ -9,6 +9,7 @@ import commonware
 import cronjobs
 
 from .models import Package
+from . import tasks
 
 log = commonware.log.getLogger('f.cron')
 
@@ -76,3 +77,8 @@ def package_activity():
             num_active = num_active + 1
 
     log.info('Finished updating daily activity. %d active today.' % num_active)
+
+
+@cronjobs.register
+def fill_package_activity():
+    tasks.fill_package_activity.delay()

--- a/apps/jetpack/cron.py
+++ b/apps/jetpack/cron.py
@@ -8,6 +8,8 @@ from django.conf import settings
 import commonware
 import cronjobs
 
+from .models import Package
+
 log = commonware.log.getLogger('f.cron')
 
 def _prune_older_files(directory, age):
@@ -59,11 +61,18 @@ def package_activity():
     log.info('Start updating Package daily activity.')
     pkgs = Package.objects.filter(deleted=False)
 
+    num_active = 0
+
     # update daily_activity if is_active_today
     # reset all Packages is_active_today to false
     for pkg in pkgs:
+
         bit = '1' if pkg.is_active_today else '0'
         pkg.year_of_activity = bit + pkg.year_of_activity[-1]
         pkg.is_active_today = False
         pkg.save()
 
+        if bit == '1':
+            num_active = num_active + 1
+
+    log.info('Finished updating daily activity. %d active today.' % num_active)

--- a/apps/jetpack/models.py
+++ b/apps/jetpack/models.py
@@ -2238,11 +2238,13 @@ def index_package(instance, **kwargs):
 
 post_save.connect(index_package, sender=Package)
 
-def mark_active_today(instance, **kw):
-    if instance.package:
-        instance.package.is_active_today = True
-        instance.package.save()
-pre_save.connect(mark_active_today, sender=PackageRevision)
+def mark_active_today(instance, created, **kw):
+    if kw.get('raw', False) or created or not instance.package_id:
+        return
+
+    instance.package.is_active_today = True
+    instance.package.save()
+post_save.connect(mark_active_today, sender=PackageRevision)
 
 unindex_package = lambda instance, **kwargs: instance.remove_from_index()
 post_delete.connect(unindex_package, sender=Package)

--- a/apps/jetpack/models.py
+++ b/apps/jetpack/models.py
@@ -1471,7 +1471,7 @@ class Package(BaseModel, SearchMixin):
 
     # activity
     year_of_activity = models.CharField(max_length=365, default='0'*365)
-    is_active_today = models.BooleanField(default=False, blank=True)
+    is_active_today = models.BooleanField(default=False)
 
     class Meta:
         " Set the ordering of objects "
@@ -2239,8 +2239,10 @@ def index_package(instance, **kwargs):
 post_save.connect(index_package, sender=Package)
 
 def mark_active_today(instance, **kw):
-    instance.is_active_today = True
-pre_save.connect(mark_active_today, sender=Package)
+    if instance.package:
+        instance.package.is_active_today = True
+        instance.package.save()
+pre_save.connect(mark_active_today, sender=PackageRevision)
 
 unindex_package = lambda instance, **kwargs: instance.remove_from_index()
 post_delete.connect(unindex_package, sender=Package)

--- a/apps/jetpack/tasks.py
+++ b/apps/jetpack/tasks.py
@@ -1,0 +1,34 @@
+import datetime
+import commonware.log
+from celery.decorators import task
+
+from .models import Package
+
+log = commonware.log.getLogger('f.celery')
+
+@task
+def fill_package_activity(*args, **kwargs):
+    """
+    Collect all the revisions for each package, distinct by day, in the past year
+    and determine the year of activity.
+    """
+    log.info('Inserting initial year_of_activity data.')
+    pkgs = Package.objects.filter(deleted=False)
+    now = datetime.datetime.utcnow()
+    last_year = now - datetime.timedelta(365)
+
+    for pkg in pkgs:
+        revs = (pkg.revisions.filter(created_at__gte=last_year)
+                .order_by('-created_at'))
+
+        activity = list('0'*365)
+
+        for rev in revs:
+            day = (now - rev.created_at).days
+            activity[day] = '1'
+
+        pkg.year_of_activity = ''.join(activity)
+        pkg.save()
+
+    log.info('Finished filling year_of_activity.')
+

--- a/apps/jetpack/tasks.py
+++ b/apps/jetpack/tasks.py
@@ -27,8 +27,9 @@ def fill_package_activity(*args, **kwargs):
             day = (now - rev.created_at).days
             activity[day] = '1'
 
+
         pkg.year_of_activity = ''.join(activity)
         pkg.save()
 
-    log.info('Finished filling year_of_activity.')
+    log.info('Finished filling year_of_activity in packages.')
 

--- a/apps/jetpack/tests/revision_tests.py
+++ b/apps/jetpack/tests/revision_tests.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from jetpack.models import Package, PackageRevision, Module, Attachment, SDK
 from jetpack.errors import SelfDependencyException, FilenameExistException, \
         DependencyException
+from jetpack.tasks import fill_package_activity
 from base.templatetags.base_helpers import hashtag
 
 log = commonware.log.getLogger('f.test')
@@ -389,6 +390,20 @@ class PackageRevisionTest(TestCase):
         assert old_rev.name
         assert old_package.full_name
         assert old_package.name
+
+    def test_fill_package_activity(self):
+        orig = '0'*365
+        addon = Package(type='a', author=self.author)
+        addon.save()
+
+        eq_(addon.year_of_activity, orig)
+
+        fill_package_activity.delay()
+
+        addon = Package.objects.get(pk=addon.pk)
+
+        new = '1' + orig[:-1]
+        eq_(addon.year_of_activity, new)
 
     """
     Althought not supported on view and front-end,

--- a/apps/search/helpers.py
+++ b/apps/search/helpers.py
@@ -56,9 +56,9 @@ ACTIVITY_MAP = {
 
 def get_activity_scale():
     avg = _get_average_activity()
-    # average should be considered 1/3 (middle of Low)
+    # average should be considered 1/5 (Low)
     # so total percentage is triple the average
-    total = avg * 3
+    total = avg * 5
 
     act_map = dict((k, v*total) for k, v in ACTIVITY_MAP.items())
 
@@ -78,7 +78,7 @@ def _get_average_activity():
     if num > 0:
         average = sum(v[1] for v in values) / len(values)
     else:
-        average = 0.33
+        average = 0.2
 
     cache.set(ACTIVITY_CACHE_KEY, average, 60*60*24)
     return average

--- a/migrations/015-initial_activity_data.py
+++ b/migrations/015-initial_activity_data.py
@@ -2,28 +2,8 @@
 Collect all the revisions for each package, distinct by day, in the past year
 and determine the year of activity.
 """
-
-import commonware
-import datetime
-from jetpack.models import Package
-log = commonware.log.getLogger('f.migrations')
+from jetpack.cron import fill_package_activity
 
 def run(*args, **kwargs):
-    log.debug('Inserting initial activity data.')
-    pkgs = Package.objects.filter(deleted=False)
-    now = datetime.datetime.utcnow()
-    last_year = now - datetime.timedelta(365)
-
-    for pkg in pkgs:
-        revs = (pkg.revisions.filter(created_at__gte=last_year)
-                .order_by('-created_at'))
-
-        activity = list('0'*365)
-
-        for rev in revs:
-            day = (now - rev.created_at).days
-            activity[day] = '1'
-
-        pkg.year_of_activity = ''.join(activity)
-        pkg.save()
+    fill_package_activity()
 


### PR DESCRIPTION
The cron was not running correctly. This fixes that.

It also moves the bulk of the migration into a task, for celery goodness. And it's registered as a cron, because we will need to run it next push to backfill the days that got left behind.
