### PR TITLE
improve updating of the year_of_activity

### DIFF
--- a/apps/jetpack/cron.py
+++ b/apps/jetpack/cron.py
@@ -59,26 +59,9 @@ def package_activity():
 
     Should be run nightly.
     """
-    log.info('Start updating Package daily activity.')
-    pkgs = Package.objects.filter(deleted=False)
-
-    num_active = 0
-
-    # update daily_activity if is_active_today
-    # reset all Packages is_active_today to false
-    for pkg in pkgs:
-
-        bit = '1' if pkg.is_active_today else '0'
-        pkg.year_of_activity = bit + pkg.year_of_activity[-1]
-        pkg.is_active_today = False
-        pkg.save()
-
-        if bit == '1':
-            num_active = num_active + 1
-
-    log.info('Finished updating daily activity. %d active today.' % num_active)
+    tasks.fill_package_activity.delay(full_year=False)
 
 
 @cronjobs.register
 def fill_package_activity():
-    tasks.fill_package_activity.delay()
+    tasks.fill_package_activity.delay(full_year=True)

--- a/apps/jetpack/models.py
+++ b/apps/jetpack/models.py
@@ -1471,7 +1471,7 @@ class Package(BaseModel, SearchMixin):
 
     # activity
     year_of_activity = models.CharField(max_length=365, default='0'*365)
-    is_active_today = models.BooleanField(default=False)
+    activity_updated_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:
         " Set the ordering of objects "
@@ -2237,14 +2237,6 @@ def index_package(instance, **kwargs):
     index_one.delay(instance.id)
 
 post_save.connect(index_package, sender=Package)
-
-def mark_active_today(instance, created, **kw):
-    if kw.get('raw', False) or created or not instance.package_id:
-        return
-
-    instance.package.is_active_today = True
-    instance.package.save()
-post_save.connect(mark_active_today, sender=PackageRevision)
 
 unindex_package = lambda instance, **kwargs: instance.remove_from_index()
 post_delete.connect(unindex_package, sender=Package)

--- a/apps/jetpack/tasks.py
+++ b/apps/jetpack/tasks.py
@@ -7,29 +7,42 @@ from .models import Package
 log = commonware.log.getLogger('f.celery')
 
 @task
-def fill_package_activity(*args, **kwargs):
+def fill_package_activity(full_year=False, *args, **kwargs):
     """
     Collect all the revisions for each package, distinct by day, in the past year
     and determine the year of activity.
     """
-    log.info('Inserting initial year_of_activity data.')
+    log.info('Inserting data into year_of_activity.')
     pkgs = Package.objects.filter(deleted=False)
     now = datetime.datetime.utcnow()
-    last_year = now - datetime.timedelta(365)
+    year = 365
+    last_year = now - datetime.timedelta(year)
 
     for pkg in pkgs:
-        revs = (pkg.revisions.filter(created_at__gte=last_year)
+        if full_year or not pkg.activity_updated_at:
+            days = year
+            time_since = last_year
+        else:
+            time_since = pkg.activity_updated_at
+            days = (now - time_since).days
+
+        if days <= 0:
+            continue
+
+        revs = (pkg.revisions.filter(created_at__gte=time_since)
                 .order_by('-created_at'))
 
-        activity = list('0'*365)
+        activity = list('0'*days)
 
         for rev in revs:
             day = (now - rev.created_at).days
             activity[day] = '1'
 
 
-        pkg.year_of_activity = ''.join(activity)
+        activity = ''.join(activity)
+        pkg.year_of_activity = activity + pkg.year_of_activity[:-days]
+        pkg.activity_updated_at = now
         pkg.save()
 
-    log.info('Finished filling year_of_activity in packages.')
+    log.info('Finished filling data into year_of_activity.')
 

--- a/migrations/018-remove_package_is_active_today.sql
+++ b/migrations/018-remove_package_is_active_today.sql
@@ -1,0 +1,2 @@
+ALTER TABLE jetpack_package DROP COLUMN is_active_today;
+ALTER TABLE jetpack_package ADD COLUMN activity_updated_at DATETIME;

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -89,3 +89,7 @@ def update_flightdeck(ctx):
     # Run management commands like this:
     # manage_cmd(ctx, 'cmd')
 
+    # For 0.9.15 only
+    manage_cmd(ctx, 'cron fill_package_activity')
+
+


### PR DESCRIPTION
Instead of keeping a flag of is_active_today (which no longer matters if the 
cron doesn't get run every day, or is out of sync), this records the 
timestamp of each time the year_of_activity is updated.

Therefore, if the cron failed to run (or any other such problem), we would 
still know how many days since the last activity investigation, and be able to
update just those days.

@pennyfx r?
