### PR TITLE
jsHint fixes

### DIFF
--- a/apps/base/templates/base.html
+++ b/apps/base/templates/base.html
@@ -37,6 +37,10 @@
 			var settings = {
 				{% block app_settings %}{% endblock %}{% block page_settings %}{% endblock %}
 				addons_helper: '{{ settings.ADDONS_HELPER_URL }}',
+                {% if waffle.switch('checkAddonsHelperVersion') %}
+                    addons_helper_version: '{{
+                        settings.ADDONS_HELPER_VERSION }}',
+                {% endif %}
 				person_login_url: '{{ login_url }}',
 				jp_addon_create_url: '{{ url('jp_addon_create') }}',
 				jp_library_create_url: '{{ url('jp_library_create') }}',

--- a/media/base/js/FlightDeck.js
+++ b/media/base/js/FlightDeck.js
@@ -12,14 +12,14 @@ Request = Class.refactor(Request, {
             if (this.options.addOnFailure) {
               this.options.addOnFailure();
             }
-			if (xhr.status != 0 && xhr.responseText) {
+			if (xhr.status !== 0 && xhr.responseText) {
                 response = xhr.responseText;
                 if (this.headers['X-Request'] == 'JSON') {
                     try {
                         response = JSON.decode(response);
                     } catch(err) {
                         // u'some string' is not valid JSON
-                    };
+                    }
                 }
 				fd.error.alert(xhr.statusText, response);
 			}
@@ -29,7 +29,7 @@ Request = Class.refactor(Request, {
     processScripts: function(text){
         if (this.options.evalResponse) return Browser.exec(text);
         return text.stripScripts(this.options.evalScripts);
-    },
+    }
 });
 
 XPIRequest = new Class({
@@ -44,7 +44,7 @@ XPIRequest = new Class({
                 if (this.options.addOnFailure) {
                   this.options.addOnFailure();
                 }
-                if (xhr.status != 0 && xhr.responseText) {
+                if (xhr.status !== 0 && xhr.responseText) {
                     fd.error.alert(
                         '{statusText}'.substitute(xhr),
                         '{responseText}'.substitute(xhr)
@@ -54,7 +54,7 @@ XPIRequest = new Class({
         }
     },
     initialize: function(cancel_callback, options) {
-        this.cancel_callback = cancel_callback,
+        this.cancel_callback = cancel_callback;
         this.parent(options);
     }
 });
@@ -72,7 +72,7 @@ Events.implement({
             if(counter < 1) {
                 this.removeEvent(type, volatileFn);
             }
-        }
+        };
         this.addEvent(type, volatileFn, internal);
     }
 });
@@ -162,7 +162,7 @@ var FlightDeck = new Class({
     whenAddonInstalled: function(callback) {
         var removeListener = function() {
             document.body.removeEventListener('addonbuilderhelperstart', callback, false);
-        }
+        };
         document.body.addEventListener('addonbuilderhelperstart', callback, false);
         (function() {
             $log('FD: Warning: not listening to addonbuilderhelperstart, is Helper installed?');
@@ -187,7 +187,7 @@ var FlightDeck = new Class({
      * Method: downloadXPI it's running in Request's scope
      */
     downloadXPI: function(response) {
-        var time = fd.options.request_interval
+        var time = fd.options.request_interval;
         
         $log('FD: DEBUG: XPI delayed ... try to load every ' + time/1000 + ' seconds' );
         var hashtag = this.options.data.hashtag;
@@ -236,7 +236,9 @@ var FlightDeck = new Class({
     },
 
     /*
-     * Method: testXPI it's running in Request's scope
+     * Method: testXPI 
+     *
+     * it's running in Request's scope
      */
     testXPI: function(response) {
         $log('FD: DEBUG: XPI delayed ... try to load every ' + fd.options.request_interval/1000 + ' seconds' );
@@ -269,7 +271,7 @@ var FlightDeck = new Class({
                 var cancel_callback = function() {
                     clearInterval(test_request.install_ID);
                     test_request.spinner.destroy();
-                }
+                };
                 test_request.install_xpi_request = new XPIRequest(
                     cancel_callback, {
                     method: 'get',
@@ -338,9 +340,27 @@ var FlightDeck = new Class({
     },
 
     /*
+     * Method: alertIfOldHelper
+     * Show a warning if old add-on builder helper is installed
+     */
+    alertIfOldHelper: function() {
+        if (settings.addons_helper_version && window.mozFlightDeck) {
+            response = window.mozFlightDeck.send({cmd: 'version'});
+            if (!response.success || response.msg < settings.addons_helper_version) {
+                fd.warning.alert(
+                        'Upgrade Add-on Builder Helper',
+                        'There is a newer version ({addons_helper_version}) available.<br/> Please install <a href="{addons_helper}">the current one</a>.'.substitute(settings));
+            } else alert('WTF?')
+        }
+    },
+
+
+
+    /*
      * Method: alertIfNoAddOn
      */
     alertIfNoAddOn: function(callback, text, title) {
+        this.alertIfOldHelper();
         if (this.isAddonInstalled()) return true;
         text = [text,
                 "To test this add-on, please install the <a id='install_addon_helper' href='{addons_helper}'>Add-on Builder Helper add-on</a>".substitute(settings)].pick();
@@ -432,9 +452,8 @@ Element.implement({
     isHidden: function(){
         var w = this.offsetWidth, h = this.offsetHeight,
         force = (this.tagName.toLowerCase() === 'tr');
-        return (w===0 && h===0 && !force)
-            ? true
-            : (w!==0 && h!==0 && !force) ? false : this.getStyle('display') === 'none';
+        return (w===0 && h===0 && !force) ? 
+            true : (w!==0 && h!==0 && !force) ? false : this.getStyle('display') === 'none';
     },
     isVisible: function(){
         return !this.isHidden();
@@ -500,7 +519,7 @@ Form.Validator.addAllThese([
             return text;
         },
         escapeAll: function() {
-            return this.escapeHTML()//.escapeJS();
+            return this.escapeHTML(); //.escapeJS();
         }
     });
 })();
@@ -528,5 +547,5 @@ window.addEvent('load', function() {
 window.addEvent('domready', function() {
     $$('.emptyreset').forEach(function(el) {
         el.set('value', '');
-    })
-})
+    });
+});

--- a/media/base/js/FlightDeck.js
+++ b/media/base/js/FlightDeck.js
@@ -344,13 +344,14 @@ var FlightDeck = new Class({
      * Show a warning if old add-on builder helper is installed
      */
     alertIfOldHelper: function() {
+        var response;
         if (settings.addons_helper_version && window.mozFlightDeck) {
             response = window.mozFlightDeck.send({cmd: 'version'});
             if (!response.success || response.msg < settings.addons_helper_version) {
                 fd.warning.alert(
                         'Upgrade Add-on Builder Helper',
                         'There is a newer version ({addons_helper_version}) available.<br/> Please install <a href="{addons_helper}">the current one</a>.'.substitute(settings));
-            } else alert('WTF?')
+            }
         }
     },
 

--- a/migrations/025-add_disabled_checkAddonHelperVersion_switch.sql
+++ b/migrations/025-add_disabled_checkAddonHelperVersion_switch.sql
@@ -1,0 +1,1 @@
+INSERT INTO `waffle_switch` (name, active, note) VALUES ('checkAddonsHelperVersion',0,'Should system check if the Add-ons Builder Helper is the current one?\r\nShould be switched on after this bug is fixed: https://bugzilla.mozilla.org/show_bug.cgi?id=687138\r\n');

--- a/settings.py
+++ b/settings.py
@@ -217,7 +217,7 @@ SESSION_COOKIE_NAME = "bamo_sessionid"
 TEMPLATE_LOADERS = (
     'jingo.Loader',
     'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',    
+    'django.template.loaders.app_directories.Loader',
 )
 
 JINGO_EXCLUDE_APPS = [
@@ -267,6 +267,7 @@ ROOT_URLCONF = 'urls'
 
 ADDONS_HELPER_URL = ('https://addons.mozilla.org/firefox/downloads/latest/'
                     '182410?src=external-builder')
+ADDONS_HELPER_VERSION = '1.2.2'
 
 TEMPLATE_DIRS = ()
 


### PR DESCRIPTION
Alert if Add-ons Builder helper is not the current one

WARNING: switch checkAddonHelperVersion after addon Add-pons Builder
Helper will respond with version number to
window.mozFlightDeck.send({cmd: 'version'});

fixes https://bugzilla.mozilla.org/show_bug.cgi?id=687138
