### PR TITLE
Uncomplete add-ons fix attempt

### DIFF
--- a/apps/jetpack/models.py
+++ b/apps/jetpack/models.py
@@ -1666,7 +1666,7 @@ class Package(BaseModel, SearchMixin):
         """
         full_name = self.full_name if not basic_name else basic_name
         if '(copy ' in full_name:
-            full_name = full_name.split('(copy')[0]
+            full_name = full_name.split(' (copy')[0]
         new_name = '%s (copy %d)' % (full_name, iteration)
         try:
             Package.objects.get(name=make_name(new_name))


### PR DESCRIPTION
Add-ons without `latest` might happen if error is raised after add-on has been created and before it's revision has been saved to database.
- fix adding space to every copy full_name
- logging the copy action
- transaction.commit_on_success added to avoid uncomplete addons - if error
  created in PackageRevision creation
