### PR TITLE
Truncate long descriptions on landing page

### DIFF
--- a/apps/jetpack/templates/_package_browser_addon.html
+++ b/apps/jetpack/templates/_package_browser_addon.html
@@ -12,7 +12,9 @@
         version <span class="version-name">{{ item.latest.get_version_name()}}</span>
     </span>
 </h3>
-<p>{{ item.description }}</p>
+<p data-text="{{item.description}}"
+       class="description {{ 'truncate' if item.description|length > 170  else ''}}">
+        {{ item.description|truncate(170) }}</p>
 
 <ul class="UI_Actions">
 	<li class="UI_Try_in_Browser XPI_test">

--- a/apps/jetpack/templates/_package_browser_library.html
+++ b/apps/jetpack/templates/_package_browser_library.html
@@ -9,7 +9,9 @@
         version <span class="version-name">{{ item.version_name }}</span>
     </span>
 </h3>
-<p>{{ item.description }}</p>
+<p data-text="{{item.description}}"
+       class="description {{ 'truncate' if item.description|length > 170  else ''}}">
+        {{ item.description|truncate(170) }}</p>
 
 <ul class="UI_Actions">
 	{% include "_package_edit_view_source_bar.html" %}

--- a/apps/person/templates/user_addons.html
+++ b/apps/person/templates/user_addons.html
@@ -1,6 +1,6 @@
 {% extends "dashboard.html" %}
 
-{% block title %}Your {% if disabled %}Disabled{% else %}Latest{% endif %} Add-ons - {% endblock %}
+{% block title %}Your {% if disabled %}Private{% else %}Latest{% endif %} Add-ons - {% endblock %}
 
 {% block head %}
 	<link rel="stylesheet" href="/media/jetpack/css/UI.Browser.css" type="text/css" media="screen" />
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block app_content %}
-	<h2 class="UI_Heading">Your {% if disabled %}Disabled{% else %}Latest{% endif %} Add-ons</h2>
+	<h2 class="UI_Heading">Your {% if disabled %}Private{% else %}Latest{% endif %} Add-ons</h2>
 	<ul class="UI_Browser">
 		{% for item in pager.object_list %}
 			<li class="UI_Item">
@@ -27,7 +27,11 @@
                 {% if pager.has_previous() %}
                     <li class="UI_Pagin_Action prev">
                         <span></span>
-                        <a title="" href="{{ url('person_addons_page', pager.previous_page_number()) }}">
+						{% if disabled %}
+							<a title="" href="{{ url('person_disabled_addons_page', pager.previous_page_number()) }}">
+						{% else %}
+							<a title="" href="{{ url('person_addons_page', pager.previous_page_number()) }}">
+						{% endif%}
                             Previous
                         </a>
                     </li>
@@ -35,7 +39,11 @@
                 <li class='current'>{{ pager.number }}</li>
                 {% if pager.has_next() %}
                     <li class="UI_Pagin_Action next">
-                        <a title="" href="{{ url('person_addons_page', pager.next_page_number()) }}">Next</a>
+						{% if disabled %}
+                        <a title="" href="{{ url('person_disabled_addons_page', pager.next_page_number()) }}">Next</a>
+						{% else %}
+						<a title="" href="{{ url('person_addons_page', pager.next_page_number()) }}">Next</a>
+						{% endif %}
                         <span></span>
                     </li>
                 {% endif %}

--- a/apps/person/templates/user_libraries.html
+++ b/apps/person/templates/user_libraries.html
@@ -1,6 +1,6 @@
 {% extends "dashboard.html" %}
 
-{% block title %}Your {% if disabled %}Disabled{% else %}Latest{% endif %} Libraries - {% endblock %}
+{% block title %}Your {% if disabled %}Private{% else %}Latest{% endif %} Libraries - {% endblock %}
 
 {% block head %}
 	<link rel="stylesheet" href="/media/jetpack/css/UI.Browser.css" type="text/css" media="screen" />
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block app_content %}
-	<h2 class="UI_Heading">Your {% if disabled %}Disabled{% else %}Latest{% endif %} Libraries</h2>
+	<h2 class="UI_Heading">Your {% if disabled %}Private{% else %}Latest{% endif %} Libraries</h2>
 	<ul class="UI_Browser">
 		{% for item in pager.object_list %}
 			<li class="UI_Item">
@@ -20,7 +20,11 @@
                 {% if pager.has_previous() %}
                     <li class="UI_Pagin_Action prev">
                         <span></span>
-                        <a title="" href="{{ url('person_libraries_page', pager.previous_page_number() ) }}">
+						{% if disabled %}
+							<a title="" href="{{ url('person_disabled_libraries_page', pager.previous_page_number() ) }}">
+						{% else %}
+							<a title="" href="{{ url('person_libraries_page', pager.previous_page_number() ) }}">							
+						{% endif %}
                             Previous
                         </a>
                     </li>
@@ -28,7 +32,11 @@
                 <li class='current'>{{ pager.number }}</li>
                 {% if pager.has_next() %}
                     <li class="UI_Pagin_Action next">
-                        <a title="" href="{{ url('person_libraries_page', pager.next_page_number() ) }}">Next</a>
+						{% if disabled %}
+                        <a title="" href="{{ url('person_disabled_libraries_page', pager.next_page_number() ) }}">Next</a>
+						{% else %}
+						<a title="" href="{{ url('person_libraries_page', pager.next_page_number() ) }}">Next</a>
+						{% endif %}
                         <span></span>
                     </li>
                 {% endif %}

--- a/apps/person/views.py
+++ b/apps/person/views.py
@@ -99,6 +99,7 @@ def dashboard_browser(r, page_number=1, type=None, disabled=False):
             'pager': pager,
             'author': author,
             'addons': addons,
+            'disabled': disabled,
             'libraries': libraries,
             'disabled_addons': disabled_addons,
             'disabled_libraries': disabled_libraries,

--- a/media/base/js/FlightDeck.js
+++ b/media/base/js/FlightDeck.js
@@ -557,4 +557,10 @@ window.addEvent('domready', function() {
     $$('.emptyreset').forEach(function(el) {
         el.set('value', '');
     });
+	
+	$('app-body').addEvent('click:relay(.truncate)', function(e){
+				var tmp = this.get('data-text');
+				this.set('data-text',this.get('text'));
+				this.set('text', tmp);
+	});
 });

--- a/media/jetpack/css/UI.Landing_Page.css
+++ b/media/jetpack/css/UI.Landing_Page.css
@@ -418,3 +418,6 @@ body .UI_middleWrapper.page {
 		.moreInfo a {
 			color: #478CDE;
 		}
+.truncate {
+	cursor: pointer;
+}

--- a/media/search/js/Search.js
+++ b/media/search/js/Search.js
@@ -211,11 +211,5 @@ window.addEvent('domready', function() {
 		});
 	});
 	
-	$('app-body').addEvent('click:relay(#SearchResults .truncate)', function(e){
-				var tmp = this.get('data-text');
-				this.set('data-text',this.get('text'));
-				this.set('text', tmp);
-	});
-
 	SearchResult.setupUI();
 });


### PR DESCRIPTION
- Moved open/close description toggle to Flightdeck.js so it can be used anywhere
- Fix for Bug 709912, private/disabled package paging was broken
