### PR TITLE
Added semi-colons to each line for migration 029

### DIFF
--- a/migrations/029-change_charset.sql
+++ b/migrations/029-change_charset.sql
@@ -1,4 +1,4 @@
-ALTER TABLE jetpack_module CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci
-ALTER TABLE jetpack_attachment CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci
-ALTER TABLE jetpack_package CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci
-ALTER TABLE jetpack_packagerevision CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci
+ALTER TABLE jetpack_module CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE jetpack_attachment CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE jetpack_package CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE jetpack_packagerevision CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;


### PR DESCRIPTION
This migration was failing

ERROR 1064 (42000) at line 2: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'ALTER TABLE jetpack_attachment CONVERT TO CHARACTER SET utf8 COLLATE utf8_genera' at line 2
