### PR TITLE
a users first addon will use the template "js/first_addon.js"

### DIFF
--- a/apps/jetpack/templates/js/first_addon.js
+++ b/apps/jetpack/templates/js/first_addon.js
@@ -1,0 +1,44 @@
+// The main module of the {{name}} Add-on.
+
+// Modules needed are `require`d, similar to CommonJS modules.
+// In this case, creating a Widget that opens a new tab needs both the
+// `widget` and the `tabs` modules.
+var Widget = require("widget").Widget;
+var tabs = require('tabs');
+
+exports.main = function() {
+
+    // Widget documentation: https://addons.mozilla.org/en-US/developers/docs/sdk/latest/packages/addon-kit/docs/widget.html
+
+    new Widget({
+        // Mandatory string used to identify your widget in order to
+        // save its location when the user moves it in the browser.
+        // This string has to be unique and must not be changed over time.
+        id: "{{name}}-widget-1",
+
+        // A required string description of the widget used for
+        // accessibility, title bars, and error reporting.
+        label: "My Mozilla Widget",
+
+
+        // An optional string URL to content to load into the widget.
+        // This can be local content or remote content, an image or
+        // web content. Widgets must have either the content property
+        // or the contentURL property set.
+        //
+        // If the content is an image, it is automatically scaled to
+        // be 16x16 pixels.
+        contentURL: "http://www.mozilla.org/favicon.ico",
+
+        // Add a function to trigger when the Widget is clicked.
+        onClick: function(event) {
+            
+            // Tabs documentation: https://addons.mozilla.org/en-US/developers/docs/sdk/latest/packages/addon-kit/docs/tabs.html
+
+            // Open a new tab in the currently active window.
+            tabs.open("http://www.mozilla.org");
+
+        }
+    });
+};
+

--- a/apps/jetpack/tests/package_tests.py
+++ b/apps/jetpack/tests/package_tests.py
@@ -436,3 +436,16 @@ class PackageTest(TestCase):
                 active=False)
         assert not addon.can_view()
         assert addon.can_view(author)
+
+    def test_first_addon_template(self):
+        author = User.objects.create(username='first-time')
+        addon = Package(full_name='First Addon', author=author, type='a')
+        addon.save()
+        mod = addon.latest.modules.all()[0]
+        assert 'id: "first-addon-widget' in mod.code
+
+        addon2 = Package(full_name='Second Addon', author=author, type='a')
+        addon2.save()
+        mod2 = addon2.latest.modules.all()[0]
+        assert 'id: "second-addon-widget' not in mod2.code
+


### PR DESCRIPTION
This includes an add-on that should work immediately, and has comments about each line, along with links to the related documenation.

fixes Bug 706838 - A user's first add-on should be a template from the Tutorial
