### PR TITLE
Bug 724648 amo api for auth

### DIFF
--- a/apps/amo/authentication.py
+++ b/apps/amo/authentication.py
@@ -1,16 +1,11 @@
 import hashlib
 import commonware
-import traceback
-import sys
 
 from django.contrib.auth.models import User
-from django.core.mail import mail_admins
 from django.utils.encoding import smart_str
-from django.conf import settings
 
-from amo.helpers import get_amo_cursor, fetch_amo_user
+from amo.helpers import fetch_amo_user
 from person.models import Profile
-from utils.amo import AMOOAuth
 
 DEFAULT_AMO_PASSWORD = 'saved in AMO'
 
@@ -27,9 +22,6 @@ class AMOAuthentication:
         """
             Authenticate user by contacting with AMO
         """
-
-        # TODO: Validate alphanum + .-_@
-
         # check if username exists in database
         try:
             user = User.objects.get(username=username)
@@ -39,7 +31,7 @@ class AMOAuthentication:
                 if user.check_password(password):
                     try:
                         profile = user.get_profile()
-                    except:
+                    except Profile.DoesNotExist:
                         # create empty profile for users stored in FD database
                         profile = Profile(user=user)
                         profile.save()
@@ -53,7 +45,7 @@ class AMOAuthentication:
     def get_user(self, user_id):
         try:
             return User.objects.get(pk=user_id)
-        except:
+        except User.DoesNotExist:
             return None
 
     def auth_db_authenticate(self, username, password):

--- a/apps/amo/authentication.py
+++ b/apps/amo/authentication.py
@@ -39,7 +39,7 @@ class AMOAuthentication:
                 return None
         except User.DoesNotExist:
             # username does not exist in FD database
-            user = None
+            return None
         return None
 
     def get_user(self, user_id):
@@ -47,25 +47,6 @@ class AMOAuthentication:
             return User.objects.get(pk=user_id)
         except User.DoesNotExist:
             return None
-
-    def auth_db_authenticate(self, username, password):
-        " authenticate email/password pair in AMO database "
-
-        user_data = AMOAuthentication.fetch_amo_user(username)
-
-        if '$' not in user_data['password']:
-            valid = (get_hexdigest('md5', '',
-                                   password) == user_data['password'])
-        else:
-            algo, salt, hsh = user_data['password'].split('$')
-            valid = (hsh == get_hexdigest(algo, salt, password))
-
-        if not valid:
-            return None
-
-        username = user_data['id']
-        self.user_data = user_data
-        return username
 
     @staticmethod
     def auth_browserid_authenticate(email):

--- a/apps/amo/helpers.py
+++ b/apps/amo/helpers.py
@@ -1,7 +1,10 @@
 import commonware.log
+import urllib2
+
 from django.conf import settings
 from lxml import etree
-import urllib2
+
+from utils.amo import AMOOAuth
 
 log = commonware.log.getLogger('f.amo')
 
@@ -65,3 +68,13 @@ def get_addon_details(amo_id, amo_file_id=None):
             amo_data['status_code'] = int(element.get('id'))
     # return dict
     return amo_data
+
+
+def fetch_amo_user(email):
+    amo = AMOOAuth(domain=settings.AMOOAUTH_DOMAIN,
+                   port=settings.AMOOAUTH_PORT,
+                   protocol=settings.AMOOAUTH_PROTOCOL,
+                   prefix=settings.AMOOAUTH_PREFIX)
+    amo.set_consumer(consumer_key=settings.AMOOAUTH_CONSUMERKEY,
+                     consumer_secret=settings.AMOOAUTH_CONSUMERSECRET)
+    return amo.get_user_by_email(email) or None

--- a/apps/amo/helpers.py
+++ b/apps/amo/helpers.py
@@ -25,20 +25,6 @@ def get_addon_amo_api_url(id, file_id):
     return url
 
 
-def get_amo_cursor():
-    import MySQLdb
-    try:
-        auth_conn = MySQLdb.connect(
-            host=settings.AUTH_DATABASE['HOST'],
-            user=settings.AUTH_DATABASE['USER'],
-            passwd=settings.AUTH_DATABASE['PASSWORD'],
-            db=settings.AUTH_DATABASE['NAME'])
-    except Exception, err:
-        log.critical("Authentication database connection failure: %s"
-                % str(err))
-        raise
-    return auth_conn.cursor()
-
 def get_addon_details(amo_id, amo_file_id=None):
     """Pull metadata from AMO using `generic AMO API
     <https://developer.mozilla.org/en/addons.mozilla.org_%28AMO%29_API_Developers%27_Guide/The_generic_AMO_API>`_

--- a/apps/amo/tests/auth_tests.py
+++ b/apps/amo/tests/auth_tests.py
@@ -7,6 +7,7 @@ from nose import SkipTest
 from nose.tools import eq_
 
 from amo.authentication import AMOAuthentication
+from amo.helpers import fetch_amo_user
 from utils.amo import AMOOAuth
 
 
@@ -51,5 +52,5 @@ class AuthTest(TestCase):
                 "email": "some@example.com",
                 "occupation": "addon developer"
             })
-        eq_(AMOAuthentication.fetch_amo_user('some@example.com')['username'],
+        eq_(fetch_amo_user('some@example.com')['username'],
                 'some')

--- a/apps/person/models.py
+++ b/apps/person/models.py
@@ -1,11 +1,10 @@
 import commonware
 
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.db import models
 
-from amo.helpers import get_amo_cursor, fetch_amo_user
+from amo.helpers import fetch_amo_user
 from person.managers import ProfileManager
 
 log = commonware.log.getLogger('f.profile.models')

--- a/apps/person/models.py
+++ b/apps/person/models.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.db import models
 
-from amo.helpers import get_amo_cursor
+from amo.helpers import get_amo_cursor, fetch_amo_user
 from person.managers import ProfileManager
 
 log = commonware.log.getLogger('f.profile.models')
@@ -61,18 +61,7 @@ class Profile(models.Model):
 
     def update_from_AMO(self, data=None):
         if not data:
-            auth_cursor = get_amo_cursor()
-            columns = ('id', 'email', 'username', 'display_name', 'email' ,
-                       'homepage')
-
-            SQL = ('SELECT %s FROM %s WHERE id=%%s') % (
-                    ','.join(columns), settings.AUTH_DATABASE['TABLE'])
-            auth_cursor.execute(SQL, [self.user.username])
-            row = auth_cursor.fetchone()
-            data = {}
-            if row:
-                for i in range(len(row)):
-                    data[columns[i]] = row[i]
+            data = fetch_amo_user(self.user.email)
 
         if 'email' in data and self.user.email != data['email']:
             log.info('User (%s) updated email (%s)' % (

--- a/apps/person/templates/registration/login.html
+++ b/apps/person/templates/registration/login.html
@@ -54,14 +54,18 @@
 				</p>
 				<p>
 					{% if waffle.switch('browserid-login') %}
-							<div id="UI_BrowserID_Img" title="Login with BrowserID">
-									&nbsp;
-							</div><span id="login_txt">or login using the <a id="old_auth" href="">old method</a>.</span>
+                        <div id="UI_BrowserID_Img" title="Login with BrowserID">
+                            &nbsp;
+                        </div>
+                        {% if waffle.switch('show-old-login') %}
+                        <span id="login_txt">or login using the <a id="old_auth" href="">old method</a>.</span>
+                        {% endif %}
 					{% endif %}
 				</p>
 			</div>		
 		
 		
+        {% if waffle.switch('show-old-login') %}
 		<form  id="login_form" class="UI_Forms {% if not waffle.switch('browserid-login') %}show-login{% endif %}" method="post" action="{{ url('django.contrib.auth.views.login') }}" accept-charset="utf-8">
 			{{ safe_csrf_token()|safe }}
 			<fieldset>
@@ -87,6 +91,7 @@
 				</ul>
 			</div> <!-- /UI_Form_Actions -->
 		</form> <!-- /UI_Forms -->
+        {% endif %}
 		<p class="really-seriously">*You must use the same email address you use to access addons.mozilla.org for both BrowserID and standard login.</p>
 	</div> <!-- /UI_Login -->
 {% endblock %}


### PR DESCRIPTION
removed all calls for AMO database
- Show old auth only if switch is on
  this is for devs to be able to log-in without AMO API
- removed authentication against database in AMOAuthentication
- get_amo_cursor removed
