### PR TITLE
Fixed bug 777352

### DIFF
--- a/apps/jetpack/views.py
+++ b/apps/jetpack/views.py
@@ -1041,9 +1041,11 @@ def library_autocomplete(request):
 
     ids = (settings.MINIMUM_PACKAGE_ID, settings.MINIMUM_PACKAGE_ID - 1)
     notAddonKit = ~(F(id_number=ids[0]) | F(id_number=ids[1]))
+    onlyMyPrivateLibs = (F(active=True) | F(author=request.user.id))
+    
     try:
         qs = (Package.search().query(or_=package_query(q)).filter(type='l')
-                .filter(notAddonKit))
+                .filter(notAddonKit).filter(onlyMyPrivateLibs))
         found = qs[:limit]
     except Exception, ex:
         log.exception('Library autocomplete error')

--- a/apps/search/helpers.py
+++ b/apps/search/helpers.py
@@ -11,10 +11,11 @@ def package_search(searchq='', user=None, score_on=None, **filters):
 
     # This is a filtered query, that says we want to do a query, but not have
     # to deal with version_text='initial' or 'copy'
-    notInitialOrCopy = ~(F(version_name='initial') | F(version_name='copy'))
+    notInitialOrCopy = ~(F(version_name='initial') | F(version_name='copy')) 
 
     qs = Package.search().values_obj('copies_count','times_depended',
-            'activity','size').filter(notInitialOrCopy, **filters)
+            'activity','size').filter(notInitialOrCopy, 
+            **filters).filter(F(active=True))
 
     # Add type facet (minus any type filter)
     facetFilter = dict((k, v) for k, v in filters.items() if k != 'type')


### PR DESCRIPTION
- This changes makes it so we index inactive(active=false) packages but filter them out of the public search.
- There was also an issue with new packages (version_name=initial) not having their full_name value update until a new version is made.
