### PR TITLE
returning 404 on every error which is caused by adding an attachment via

### DIFF
--- a/apps/jetpack/tests/attachment_test.py
+++ b/apps/jetpack/tests/attachment_test.py
@@ -300,12 +300,12 @@ class TestViews(TestCase):
         response = self.client.post(self.get_add_url(revision), {
                     "filename": "some.txt",
                     "url": "abc"})
-        eq_(response.status_code, 400)
+        eq_(response.status_code, 404)
         # not existing url
         response = self.client.post(self.get_add_url(revision), {
                     "filename": "some.txt",
                     "url": "http://notexistingurl.pl/some.txt"})
-        eq_(response.status_code, 400)
+        eq_(response.status_code, 404)
         # malicious input
         response = self.client.post(self.get_add_url(revision), {
                     "filename": "",

--- a/media/base/js/flightdeck/request.js
+++ b/media/base/js/flightdeck/request.js
@@ -21,8 +21,12 @@ var defaultFailure = function(text) {
             log.warn('Response error is not valid JSON');
             if (text.indexOf('<html') !== -1) {
                 // We somehow got a full HTML page. Bad!
-                log.error('Response is an HTML page!');
-                response = 'Something aweful happened.';
+                if (this.status == 404) {
+                  response = 'Page not found';
+                } else {
+                  log.error('Response is an HTML page!');
+                  response = 'Something aweful happened.' + this.status;
+                }
             } else {
                 // A simple text message
                 response = text;


### PR DESCRIPTION
providing URL

changed message to "Page not found" if 404 with an HTML page is returned
