### PR TITLE
Update Flightdeck to include Add-on SDK 1.11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -79,3 +79,6 @@
 [submodule "lib/addon-sdk-1.10"]
 	path = lib/addon-sdk-1.10
 	url = git://github.com/mozilla/addon-sdk.git
+[submodule "lib/addon-sdk-1.11"]
+	path = lib/addon-sdk-1.11
+	url = git://github.com/mozilla/addon-sdk.get

--- a/settings.py
+++ b/settings.py
@@ -132,8 +132,8 @@ XPI_AMO_PREFIX = "ftp://ftp.mozilla.org/pub/mozilla.org/addons/"
 
 # The lowest approved SDK available for add-ons
 DISABLED_SDKS = ('1.4', '1.4.1', '1.4.1-w-1', '1.4.2')
-LOWEST_APPROVED_SDK = "1.10"
-TEST_SDK = 'addon-sdk-1.10'
+LOWEST_APPROVED_SDK = "1.11"
+TEST_SDK = 'addon-sdk-1.11'
 TEST_AMO_USERNAME = None
 TEST_AMO_PASSWORD = None
 AUTH_DATABASE = None


### PR DESCRIPTION
This should be everything needed to get 1.11 up on Builder. We're shipping 1.11 on Tuesday, so if we can get this stuff ready before then, that'd be awesome.
