### PR TITLE
Add SDK 1.12 to Builder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,3 +82,6 @@
 [submodule "lib/addon-sdk-1.11"]
 	path = lib/addon-sdk-1.11
 	url = git://github.com/mozilla/addon-sdk.git
+[submodule "lib/addon-sdk-1.12"]
+	path = lib/addon-sdk-1.12
+	url = git://github.com/mozilla/addon-sdk.git

--- a/settings.py
+++ b/settings.py
@@ -132,8 +132,8 @@ XPI_AMO_PREFIX = "ftp://ftp.mozilla.org/pub/mozilla.org/addons/"
 
 # The lowest approved SDK available for add-ons
 DISABLED_SDKS = ('1.4', '1.4.1', '1.4.1-w-1', '1.4.2')
-LOWEST_APPROVED_SDK = "1.11"
-TEST_SDK = 'addon-sdk-1.11'
+LOWEST_APPROVED_SDK = "1.12"
+TEST_SDK = 'addon-sdk-1.12'
 TEST_AMO_USERNAME = None
 TEST_AMO_PASSWORD = None
 AUTH_DATABASE = None


### PR DESCRIPTION
This should add SDK 1.12 to FlightDeck.
