### PR TITLE
Fixes Bug 818125

### DIFF
--- a/apps/jetpack/management/commands/add_core_lib.py
+++ b/apps/jetpack/management/commands/add_core_lib.py
@@ -1,4 +1,4 @@
-from optparse import make_option
+from optparse import make_option, OptionParser
 
 from django.core.management.base import BaseCommand
 from jetpack.management import create_SDK, update_SDK
@@ -15,11 +15,20 @@ class Command(BaseCommand):
             make_option('--useversion',
                 dest="version",
                 default=None,
-                help="Version string to show in Builder"),)
+                help="Version string to show in Builder"),
+            make_option('-i', '--import',
+                dest='should_import',
+                action='store_true',
+                default=False,
+                help="Import code to Builder"),
+            )
 
-    def handle(self, sdk_dir_name, options=None, version=None, *args, **kwargs):
+    def handle(self, sdk_dir_name, options=None, version=None,
+            should_import=False, *args, **kwargs):
         if SDK.objects.count() > 0:
-            update_SDK(sdk_dir_name, options=options, version=version)
+            update_SDK(sdk_dir_name, options=options, version=version,
+                    should_import=should_import)
         else:
-            create_SDK(sdk_dir_name, options=options, version=version)
+            create_SDK(sdk_dir_name, options=options, version=version,
+                    should_import=should_import)
         print "SDK instances created"

--- a/apps/jetpack/models.py
+++ b/apps/jetpack/models.py
@@ -334,7 +334,8 @@ class PackageRevision(BaseModel):
         """
         package_dir = self.get_dir_name(packages_dir)
         if not os.path.isdir(package_dir):
-            os.mkdir(package_dir)
+            # makedirs as SDK 1.12 doesn't have the packages directory
+            os.makedirs(package_dir)
         else:
             return False
 
@@ -1466,7 +1467,6 @@ class PackageRevision(BaseModel):
         log.debug("[xpi:%s] SDK %s copied from %s (time %dms)" % (
             hashtag, sdk.version, sdk_source, t1))
 
-
         packages_dir = os.path.join(sdk_dir, 'packages')
         package_dir = self.make_dir(packages_dir)
         # XPI: create manifest (from memory to local)
@@ -2514,7 +2514,7 @@ class SDK(BaseModel):
     # It has to be accompanied with a core library
     # needs to exist before SDK is created
     core_lib = models.OneToOneField(PackageRevision,
-            related_name="parent_sdk_core+")
+            related_name="parent_sdk_core+", blank=True, null=True)
     kit_lib = models.OneToOneField(PackageRevision,
             related_name="parent_sdk_kit+", blank=True, null=True)
     #core_name = models.CharField(max_length=100, default='jetpack-core')

--- a/apps/jetpack/templates/addon_edit.html
+++ b/apps/jetpack/templates/addon_edit.html
@@ -13,26 +13,48 @@
 
 {% block core_library %}
   {% if revision.sdk %}
-  <li class="UI_File_Normal Core_library"
-	  id="core_library_lib"
-	  title="{{ revision.get_sdk_revision().package.full_name }}"
-      data-id-number="{{ revision.get_sdk_revision().package.name }}">
-      <a class="expand" href="#"></a>
-	  <div class="holder">
-		<a href="{{ revision.get_sdk_revision().get_absolute_url() }}" target="_blank">
-		  <span class="label">{{ revision.get_sdk_revision().package.full_name }}</span>
-		</a>
-		<span class="icon"></span>
-		<select id="jetpack_core_sdk_version">
-			{% for s in sdk_list %}
-			<option value="{{ s.id }}" {% if s.is_deprecated() %}disabled{% endif %}
-				{% if revision.sdk.id == s.id %} selected{% endif %}>
-				{{ s.version }}
-			  </option>
-			{% endfor %}
-		</select>
-	  </div>
-  </li>
+	{% if revision.get_sdk_revision() %}
+	<li class="UI_File_Normal Core_library"
+		id="core_library_lib"
+		title="{{ revision.get_sdk_revision().package.full_name }}"
+		data-id-number="{{ revision.get_sdk_revision().package.name }}">
+		<a class="expand" href="#"></a>
+		<div class="holder">
+			<a href="{{ revision.get_sdk_revision().get_absolute_url() }}" target="_blank">
+			<span class="label">{{ revision.get_sdk_revision().package.full_name }}</span>
+			</a>
+			<span class="icon"></span>
+			<select id="jetpack_core_sdk_version">
+				{% for s in sdk_list %}
+				<option value="{{ s.id }}" {% if s.is_deprecated() %}disabled{% endif %}
+					{% if revision.sdk.id == s.id %} selected{% endif %}>
+					{{ s.version }}
+				</option>
+				{% endfor %}
+			</select>
+		</div>
+	</li>
+	{% else %}
+	<li class="UI_File_Normal Core_library"
+		id="core_library_lib"
+		title="SDK">
+		<a class="expand" href="#"></a>
+		<div class="holder">
+			<a href="#">
+			<span class="label">SDK</span>
+			</a>
+			<span class="icon"></span>
+			<select id="jetpack_core_sdk_version">
+				{% for s in sdk_list %}
+				<option value="{{ s.id }}" {% if s.is_deprecated() %}disabled{% endif %}
+					{% if revision.sdk.id == s.id %} selected{% endif %}>
+					{{ s.version }}
+				</option>
+				{% endfor %}
+			</select>
+		</div>
+	</li>
+	{% endif %}
   {% endif %}
 {% endblock %}
 

--- a/apps/jetpack/templates/json/sdk_switched.json
+++ b/apps/jetpack/templates/json/sdk_switched.json
@@ -2,6 +2,6 @@
 	{% include "json/_edit_urls.json" %}
 	"message_title": "Success",
 	"message": "Switched to Add-on Kit {{ sdk.version }}",
-    "lib_name": "{{ sdk_lib.full_name }}",
-    "lib_url": "{{ sdk_lib.get_absolute_url() }}"
+    "lib_name": "{% if sdk_lib %}{{ sdk_lib.full_name }}{% else %}SDK{% endif %}",
+    "lib_url": "{% if sdk_lib %}{{ sdk_lib.get_absolute_url() }}{% else %}#{% endif %}"
 }

--- a/apps/jetpack/tests/revision_tests.py
+++ b/apps/jetpack/tests/revision_tests.py
@@ -15,8 +15,8 @@ from django.conf import settings
 
 from jetpack.tasks import calculate_activity_rating
 from jetpack.models import Package, PackageRevision, Module, Attachment, SDK
-from jetpack.errors import SelfDependencyException, FilenameExistException, \
-        DependencyException
+from jetpack.errors import (SelfDependencyException, FilenameExistException,
+        DependencyException)
 
 from utils import validator
 
@@ -521,6 +521,11 @@ class PackageRevisionTest(TestCase):
     def test_zip_lib(self):
         self.library.latest.zip_source(hashtag=self.hashtag)
         assert os.path.isfile(self.zip_file)
+
+    def test_create_package_with_no_libs_in_sdk(self):
+        sdk = SDK.objects.create(version='1.12', dir='addon-sdk-1.12')
+        package = Package.objects.create(author=self.author, type='a')
+        eq_(package.latest.sdk.id, sdk.id)
 
 
     """

--- a/apps/xpi/tests/test_building.py
+++ b/apps/xpi/tests/test_building.py
@@ -489,3 +489,22 @@ require('b');
         assert response[1]
         assert not os.path.isfile('%s.xpi' % self.target_basename)
         assert os.path.exists('%s.json' % self.target_basename)
+
+    def test_building_xpi_with_1_12(self):
+        sdk = SDK.objects.create(version='1.12', dir='addon-sdk-1.12')
+        package = Package.objects.create(author=self.author, type='a')
+
+        tstart = time.time()
+        xpi_utils.sdk_copy(self.addonrev.sdk.get_source_dir(), self.SDKDIR)
+        package.latest.export_keys(self.SDKDIR)
+        package.latest.export_files_with_dependencies(
+            '%s/packages' % self.SDKDIR)
+        err = xpi_utils.build(
+                self.SDKDIR,
+                package.latest.get_dir_name('%s/packages' % self.SDKDIR),
+                package.name, self.hashtag, tstart=tstart)
+        # assert no error output
+        assert not err[1]
+        # assert xpi was created
+        assert os.path.isfile('%s.xpi' % self.target_basename)
+        assert os.path.isfile('%s.json' % self.target_basename)

--- a/migrations/033-sdk_core_lib_NULL.sql
+++ b/migrations/033-sdk_core_lib_NULL.sql
@@ -1,0 +1,1 @@
+ALTER TABLE jetpack_sdk CHANGE core_lib_id core_lib_id INT;


### PR DESCRIPTION
Add packages directory if needed (SDK 1.12 doesn't have it like older SDKs)
Allow to create empty manifests
Add SDK 1.12+ to the Builder's database
Use -i to import code
Frontend displays different data if SDK exists, but has no code
Test creation of a package with SDK 1.12
Test building with the 1.12
