### PR TITLE
doc URL fixes!

### DIFF
--- a/apps/base/templates/_header.html
+++ b/apps/base/templates/_header.html
@@ -17,7 +17,7 @@
 				<span><a title="Search" href="{{ url('search') }}">Search</a></span>
 			</li>
 			{#<li {% if page == "packages" %}class="active"{% endif %}><span><a title="Package Browser" href="{{ url('jp_browser_addons') }}">Package Browser</a></span></li>#}
-			<li><span><a title="Documentation" href="/docs/" target="new">Docs</a></span></li>
+			<li><span><a title="Documentation" href="https://addons.mozilla.org/en-US/developers/docs/sdk/latest/" target="new">Docs</a></span></li>
 			{% if user.is_authenticated() %}
 				<li {% if page == "dashboard" %}class="active"{% endif %}>
 					<span>

--- a/apps/base/templates/homepage.html
+++ b/apps/base/templates/homepage.html
@@ -55,9 +55,9 @@
             <div class="UI_Feature_Side">
                 <h3>Learn</h3>
                 <ul>
-                    <li><a href="/docs/">API Documentation</a></li>
-                    <li><a href="https://addons.mozilla.org/en-US/developers/docs/sdk/latest/packages/addon-kit/">Add-on Kit - High-level APIs</a></li>
-                    <li><a href="https://addons.mozilla.org/en-US/developers/docs/sdk/latest/packages/api-utils/">API Utilities - Low-level SDK code</a></li>
+                    <li><a href="https://addons.mozilla.org/en-US/developers/docs/sdk/latest/">API Documentation</a></li>
+                    <li><a href="https://addons.mozilla.org/en-US/developers/docs/sdk/latest/modules/high-level-modules.html">High-level SDK APIs</a></li>
+                    <li><a href="https://addons.mozilla.org/en-US/developers/docs/sdk/latest/modules/low-level-modules.html">Low-level SDK code</a></li>
                 </ul>
                 <h3 class="second">Explore</h3>
                 <ul>
@@ -112,7 +112,7 @@
 
 						<ul>
 							<li class="UI_Mini_Button"><a id="getSdk" title="Download Add-on Builder SDK" href="https://ftp.mozilla.org/pub/mozilla.org/labs/jetpack/addon-sdk-latest.zip"><span>Download Add-on Builder SDK</span></a></li>
-							<li class="moreInfo"><a title="More Info" href="/docs/">More Info</a></li>
+							<li class="moreInfo"><a title="More Info" href="https://addons.mozilla.org/en-US/developers/docs/sdk/latest/">More Info</a></li>
 						</ul>
 					</div>
 				</div> <!-- /UI_LE_Col -->

--- a/apps/jetpack/templates/js/first_addon.js
+++ b/apps/jetpack/templates/js/first_addon.js
@@ -8,7 +8,7 @@ var tabs = require('tabs');
 
 exports.main = function() {
 
-    // Widget documentation: https://addons.mozilla.org/en-US/developers/docs/sdk/latest/packages/addon-kit/widget.html
+    // Widget documentation: https://addons.mozilla.org/en-US/developers/docs/sdk/latest/modules/sdk/widget.html
 
     new Widget({
         // Mandatory string used to identify your widget in order to
@@ -33,7 +33,7 @@ exports.main = function() {
         // Add a function to trigger when the Widget is clicked.
         onClick: function(event) {
             
-            // Tabs documentation: https://addons.mozilla.org/en-US/developers/docs/sdk/latest/packages/addon-kit/tabs.html
+            // Tabs documentation: https://addons.mozilla.org/en-US/developers/docs/sdk/latest/modules/sdk/tabs.html
 
             // Open a new tab in the currently active window.
             tabs.open("http://www.mozilla.org");

--- a/apps/tutorial/templates/tutorial.html
+++ b/apps/tutorial/templates/tutorial.html
@@ -68,10 +68,10 @@ require("widget").Widget({
 	that brings you functionality from another <i>module</i>, or reusable
 	piece of code. It's through this mechanism that you'll access all of
 	the browser's awesomeness, be it <a
-	 href="/docs/sdk/latest/modules/context-menu.html">context menus</a>, <a
-	 href="/docs/sdk/latest/modules/simple-storage.html">persistent
+	 href="https://addons.mozilla.org/en-US/developers/docs/sdk/latest/modules/sdk/context-menu.html">context menus</a>, <a
+	 href="https://addons.mozilla.org/en-US/developers/docs/sdk/latest/modules/sdk/simple-storage.html">persistent
 	storage</a>, or something else entirely. In our case, we want to use
-	the <a href="/docs/sdk/latest/modules/widget.html">widget</a> module,
+	the <a href="https://addons.mozilla.org/en-US/developers/docs/sdk/latest/modules/sdk/widget.html">widget</a> module,
 	which provides a consistent, unified way for add-ons to expose their
 	user interface.</p>
 
@@ -138,7 +138,7 @@ require("widget").Widget({
 
 	<h2 class="UI_Heading">Keep On Hacking!</h2>
 
-	<p>From here, you can check out the <a href="/docs/sdk/latest/">core
+	<p>From here, you can check out the <a href="https://addons.mozilla.org/en-US/developers/docs/sdk/latest/">core
 	library documentation</a> to discover new ways to extend the
 	browser. Alternatively, you can browse <a href="{{ url('jp_browser_addons') }}">other
 	people's add-ons</a>, view their source code and see how they work.</p>


### PR DESCRIPTION
Fixes URLs for documentation, so people can actually find the documentation. There is a comment in /urls.py that "/docs are an Apache rewrite", so some of my changes could be rendered perhaps unnecessary (or require a different approach) if the Apache directive was updated.

I did not fix some URLs in /apps/jetpack/fixtures/core_sdk.json , not knowing whether this was just historical (or what it was for), whereas with /apps/jetpack/templates/js/first_addon.js , I changed the URLs as it looked like the widget might still work today, though I didn't test it (and it also used the "new" keyword in front of Widget which I guess is no longer necessary).

Even if this is imperfect, I really suggest addressing this quickly as the whole site is kind of meaningless if one can't find the docs (though "Submit to AMO" is another critical item to make the site worthwhile but at least one can still test without it if one can find the docs).
