### PR TITLE
Update FlightDeck to include SDK 1.13

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,6 @@
 [submodule "lib/addon-sdk-1.12"]
 	path = lib/addon-sdk-1.12
 	url = git://github.com/mozilla/addon-sdk.git
+[submodule "lib/addon-sdk-1.13"]
+	path = lib/addon-sdk-1.13
+	url = git://github.com/mozilla/addon-sdk.git

--- a/settings.py
+++ b/settings.py
@@ -132,8 +132,8 @@ XPI_AMO_PREFIX = "ftp://ftp.mozilla.org/pub/mozilla.org/addons/"
 
 # The lowest approved SDK available for add-ons
 DISABLED_SDKS = ('1.4', '1.4.1', '1.4.1-w-1', '1.4.2')
-LOWEST_APPROVED_SDK = "1.12"
-TEST_SDK = 'addon-sdk-1.12'
+LOWEST_APPROVED_SDK = "1.13"
+TEST_SDK = 'addon-sdk-1.13'
 TEST_AMO_USERNAME = None
 TEST_AMO_PASSWORD = None
 AUTH_DATABASE = None


### PR DESCRIPTION
This adds SDK 1.13 to FlightDeck. We're releasing 1.13 on Tuesday, so hopefully this can get taken care of in time for release.
