### PR TITLE
Bug 836606 - This adds SDK 1.13.1 support to FlightDeck

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -88,3 +88,6 @@
 [submodule "lib/addon-sdk-1.13"]
 	path = lib/addon-sdk-1.13
 	url = git://github.com/mozilla/addon-sdk.git
+[submodule "lib/addon-sdk-1.13.1"]
+	path = lib/addon-sdk-1.13.1
+	url = git://github.com/mozilla/addon-sdk.git

--- a/settings.py
+++ b/settings.py
@@ -131,9 +131,9 @@ PYTHON_EXEC = 'python'
 XPI_AMO_PREFIX = "ftp://ftp.mozilla.org/pub/mozilla.org/addons/"
 
 # The lowest approved SDK available for add-ons
-DISABLED_SDKS = ('1.4', '1.4.1', '1.4.1-w-1', '1.4.2')
-LOWEST_APPROVED_SDK = "1.13"
-TEST_SDK = 'addon-sdk-1.13'
+DISABLED_SDKS = ('1.4', '1.4.1', '1.4.1-w-1', '1.4.2', '1.13')
+LOWEST_APPROVED_SDK = "1.13.1"
+TEST_SDK = 'addon-sdk-1.13.1'
 TEST_AMO_USERNAME = None
 TEST_AMO_PASSWORD = None
 AUTH_DATABASE = None


### PR DESCRIPTION
We had to do a point release for Addon SDK 1.13.1 to fix several issues, see https://bugzilla.mozilla.org/show_bug.cgi?id=836564 for the gory details. This PR adds 1.13.1 support to Builder, and deprecates 1.13.
