### PR TITLE
Add 'permissions' to allowed keys.

### DIFF
--- a/apps/jetpack/models.py
+++ b/apps/jetpack/models.py
@@ -793,7 +793,7 @@ class PackageRevision(BaseModel):
     @staticmethod
     def validate_extra_json(extra_json):
         allowed_keys = ('contributors', 'homepage', 'icon', 'icon64', 'id',
-                'preferences', 'license')
+                'preferences', 'license', 'permissions')
         for key in extra_json.keys():
             if key not in allowed_keys:
                 raise KeyNotAllowed(allowed_keys)


### PR DESCRIPTION
SDK 1.14 will add a 'permissions' key to package.json, initially used only for allowing addons to opt-in to running in private browsing windows, with other potential uses in the future. This commit adds support for the key so developers don't get errors when trying to add the key to their addons.
