### PR TITLE
Add SDK 1.14rc1 to dev instance of Builder for testing.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -94,3 +94,6 @@
 [submodule "lib/addon-sdk-1.13.2"]
 	path = lib/addon-sdk-1.13.2
 	url = git://github.com/mozilla/addon-sdk.git
+[submodule "lib/addon-sdk-1.14rc1"]
+	path = lib/addon-sdk-1.14rc1
+	url = git://github.com/mozilla/addon-sdk.git

--- a/apps/jetpack/models.py
+++ b/apps/jetpack/models.py
@@ -793,7 +793,7 @@ class PackageRevision(BaseModel):
     @staticmethod
     def validate_extra_json(extra_json):
         allowed_keys = ('contributors', 'homepage', 'icon', 'icon64', 'id',
-                'preferences', 'license')
+                'preferences', 'license', 'permissions')
         for key in extra_json.keys():
             if key not in allowed_keys:
                 raise KeyNotAllowed(allowed_keys)

--- a/settings.py
+++ b/settings.py
@@ -132,8 +132,8 @@ XPI_AMO_PREFIX = "ftp://ftp.mozilla.org/pub/mozilla.org/addons/"
 
 # The lowest approved SDK available for add-ons
 DISABLED_SDKS = ('1.4', '1.4.1', '1.4.1-w-1', '1.4.2', '1.13', '1.13.1')
-LOWEST_APPROVED_SDK = "1.13.2"
-TEST_SDK = 'addon-sdk-1.13.2'
+LOWEST_APPROVED_SDK = "1.14rc1"
+TEST_SDK = 'addon-sdk-1.14rc1'
 TEST_AMO_USERNAME = None
 TEST_AMO_PASSWORD = None
 AUTH_DATABASE = None


### PR DESCRIPTION
This adds 1.14rc1 to Builder (along with the change to allow users to add the "permissions" flag to be able to opt in to private browsing windows). This should NOT be pushed to production, since it's using the not-final RC build, but it would be nice to get this on the -dev server for testing the SDK.
