### PR TITLE
Update some FlightDeck tests to use the current SDK version, not SDK 1.12

### DIFF
--- a/apps/jetpack/tests/revision_tests.py
+++ b/apps/jetpack/tests/revision_tests.py
@@ -523,7 +523,7 @@ class PackageRevisionTest(TestCase):
         assert os.path.isfile(self.zip_file)
 
     def test_create_package_with_no_libs_in_sdk(self):
-        sdk = SDK.objects.create(version='1.12', dir='addon-sdk-1.12')
+        sdk = SDK.objects.create(version=settings.LOWEST_APPROVED_SDK, dir=settings.TEST_SDK)
         package = Package.objects.create(author=self.author, type='a')
         eq_(package.latest.sdk.id, sdk.id)
 

--- a/apps/xpi/tests/test_building.py
+++ b/apps/xpi/tests/test_building.py
@@ -490,8 +490,8 @@ require('b');
         assert not os.path.isfile('%s.xpi' % self.target_basename)
         assert os.path.exists('%s.json' % self.target_basename)
 
-    def test_building_xpi_with_1_12(self):
-        sdk = SDK.objects.create(version='1.12', dir='addon-sdk-1.12')
+    def test_building_xpi(self):
+        sdk = SDK.objects.create(version=settings.LOWEST_APPROVED_SDK, dir=settings.TEST_SDK)
         package = Package.objects.create(author=self.author, type='a')
 
         tstart = time.time()


### PR DESCRIPTION
According to Jenkins, 10 tests started failing back when SDK 1.13 was added to FlightDeck. Those tests seem to explicitly test SDK 1.12.

Having not run these tests myself, I'd assume we should at least be testing the now-current SDK version (1.14 at the moment), if not somehow always test the latest SDK version automatically.

This pull request changes two tests that were using 1.12 so they now use 1.14.
