### PR TITLE
Fixed the problem with Mozilla logo

### DIFF
--- a/media/jetpack/css/UI.Layout.css
+++ b/media/jetpack/css/UI.Layout.css
@@ -529,7 +529,7 @@ kbd {
 }
 
 #footer div.UI_middleWrapper {
-	background: url(../img/mozilla/logo-mozilla.gif) no-repeat 15px 0;
+	background: url(../img/mozilla/logo-mozilla.gif) no-repeat;
 	
 }
 #footer .primary {


### PR DESCRIPTION
The Firefox logo in footer is overlapping the text in the footer, its fixed with small edit in the CSS.  

Just remove the margin that is applied for the background image "#footer div.UI_middleWrap

Here is how it will look after this change and now.

![adonbuilder bug](https://f.cloud.github.com/assets/1151263/1322488/58bcd732-3431-11e3-90fc-a0917ca3989c.jpg)
